### PR TITLE
fix: add account derive

### DIFF
--- a/packages/apps-config/src/api/spec/interbtc.ts
+++ b/packages/apps-config/src/api/spec/interbtc.ts
@@ -14,6 +14,7 @@ import { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import { memo } from '@polkadot/api-derive/util';
 import { TypeRegistry, U128 } from '@polkadot/types';
 import { Balance } from '@polkadot/types/interfaces';
+import { FrameSystemAccountInfo } from '@polkadot/types/lookup';
 import { BN, formatBalance } from '@polkadot/util';
 
 function balanceOf (number: number | string): U128 {
@@ -49,11 +50,12 @@ export function getBalance (
   return memo(
     instanceId,
     (account: string): Observable<DeriveBalancesAll> =>
-      combineLatest<[any]>([api.query.tokens.accounts(account, { Token: nativeToken })]).pipe(
-        map(([data]: [OrmlAccountData]): DeriveBalancesAll => {
+      combineLatest<[any, any]>([api.query.tokens.accounts(account, { Token: nativeToken }), api.query.system.account(account)]).pipe(
+        map(([data, systemAccount]: [OrmlAccountData, FrameSystemAccountInfo]): DeriveBalancesAll => {
           return {
             ...defaultAccountBalance(),
             accountId: api.registry.createType('AccountId', account),
+            accountNonce: systemAccount.nonce,
             availableBalance: api.registry.createType('Balance', data.free.sub(data.frozen)),
             freeBalance: data.free,
             lockedBalance: data.frozen,
@@ -67,6 +69,7 @@ export function getBalance (
 const definitions: OverrideBundleDefinition = {
   derives: {
     balances: {
+      account: getBalance,
       all: getBalance
     }
   },


### PR DESCRIPTION
Without this, we run into [this issue](https://github.com/polkadot-js/apps/issues/8458) when we submit transactions on a chopsticks-ed chain. To be honest I don't understand why this change is required on chopsticks and not on mainnet, but this fix seems to work on mainnet as well so I think we can merge this.

target branch is on my fork's master - I will change to upstream master after internal review